### PR TITLE
PR - [issue #15] feature(article): Employees can delete their own articles

### DIFF
--- a/src/api/v1/controllers/articlesController.js
+++ b/src/api/v1/controllers/articlesController.js
@@ -68,6 +68,41 @@ const articlesCtrl = {
       return next(error);
     }
   },
+
+  deleteArticle: async (req, res, next) => {
+    try {
+      // get articleId from url params
+      const { articleId } = req.params;
+
+      // retrieve article from DB
+      const article = await Article.getbyId(articleId);
+
+      console.log(`article: ${JSON.stringify(article)}`);
+
+      // if article not found raise error
+      if (!article) {
+        return next(new CustomError(404, 'Article not found'));
+      }
+
+      // if article does not belong to user return error
+      if (article.user_id !== req.user.userId) {
+        return next(new CustomError(404, 'Article not found among your own articles'));
+      }
+
+      await article.deleteOne();
+
+      return responseHandler(res, 200, {
+        message: 'Article succesfully deleted',
+      });
+    } catch (error) {
+      // console.log(`error creating user: ${error.message}`);
+      if (error.message.indexOf('not found') >= 0) {
+        return next(new CustomError(404, 'Article not found'));
+      }
+
+      return next(error);
+    }
+  },
 };
 
 export default articlesCtrl;

--- a/src/api/v1/middleware/validationRules.js
+++ b/src/api/v1/middleware/validationRules.js
@@ -57,3 +57,10 @@ export const createUpdateArticleRule = () => [
     .isInt()
     .withMessage('url parameter must be an integer'),
 ];
+
+export const deleteArticleRule = () => [
+  param('articleId')
+    .exists({ checkFalsy: true }).withMessage('url parameter is required')
+    .isInt()
+    .withMessage('url parameter must be an integer'),
+];

--- a/src/api/v1/routes/articles/index.js
+++ b/src/api/v1/routes/articles/index.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import validateData from '../../middleware/validateData';
-import { createUpdateArticleRule } from '../../middleware/validationRules';
+import { createUpdateArticleRule, deleteArticleRule } from '../../middleware/validationRules';
 import articlesCtrl from '../../controllers/articlesController';
 
 const articlesRouter = express.Router();
@@ -21,6 +21,13 @@ articlesRouter.patch(
   createUpdateArticleRule(),
   validateData,
   articlesCtrl.updateArticle,
+);
+
+articlesRouter.delete(
+  '/:articleId',
+  deleteArticleRule(),
+  validateData,
+  articlesCtrl.deleteArticle,
 );
 
 export default articlesRouter;


### PR DESCRIPTION
[Closes #15 ]
#### What does this PR do?
Enables employees to delete only their own articles

#### Description of Task to be completed?
- Create route for endpoint
- Define validation rules
- Create controller to delete article through article model

#### How should this be manually tested?
- Send a DELETE request to /api/v1/articles/:articleId 
   - with a valid token
   - articleId to delete in URL params
- Expect a JSON response and status code 200 on success
