### PR TITLE
PR - [issue #16] - Employees can delete their gifs

### DIFF
--- a/src/api/v1/controllers/gifsController.js
+++ b/src/api/v1/controllers/gifsController.js
@@ -1,6 +1,6 @@
 import Gif from '../models/gif.model';
 import responseHandler from '../../utils/responseHandler';
-// import CustomError from '../../utils/customError';
+import CustomError from '../../utils/customError';
 
 const gifsCtrl = {
 
@@ -25,6 +25,36 @@ const gifsCtrl = {
       if (error.message.indexOf('file format') >= 0) {
         return next(new CustomError(422, 'Invalid file format. Only gif images allowed'));
       } */
+      return next(error);
+    }
+  },
+
+  deleteGif: async (req, res, next) => {
+    try {
+      // get gifId from url params
+      const { gifId } = req.params;
+
+      // retrieve gif from DB
+      const gif = await Gif.getbyId(gifId);
+
+      // console.log(`gif: ${JSON.stringify(gif)}`);
+
+      // if gif does not belong to user return error
+      if (gif.user_id !== req.user.userId) {
+        return next(new CustomError(404, 'Gif not found among your own gifs'));
+      }
+
+      await gif.deleteOne();
+
+      return responseHandler(res, 200, {
+        message: 'Gif succesfully deleted',
+      });
+    } catch (error) {
+      // console.log(`error creating user: ${error.message}`);
+      if (error.message.indexOf('not found') >= 0) {
+        return next(new CustomError(404, 'Gif not found'));
+      }
+
       return next(error);
     }
   },

--- a/src/api/v1/middleware/validationRules.js
+++ b/src/api/v1/middleware/validationRules.js
@@ -104,3 +104,10 @@ export const addGifCommentRule = () => [
     .isLength({ min: 1, max: 200 })
     .withMessage('field length min:1, max:200'),
 ];
+
+export const singleGifRule = () => [
+  param('gifId')
+    .exists({ checkFalsy: true }).withMessage('url parameter is required')
+    .isInt()
+    .withMessage('url parameter must be an integer'),
+];

--- a/src/api/v1/routes/gifs/index.js
+++ b/src/api/v1/routes/gifs/index.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import validateData from '../../middleware/validateData';
-import { createGifRule } from '../../middleware/validationRules';
+import { createGifRule, singleGifRule } from '../../middleware/validationRules';
 import gifsCtrl from '../../controllers/gifsController';
 import cloudinaryUploader from '../../middleware/cloudinaryUploader';
 import gifCommentsRouter from './comments';
@@ -13,6 +13,13 @@ gifsRouter.post(
   createGifRule(),
   validateData,
   gifsCtrl.createGif,
+);
+
+gifsRouter.delete(
+  '/:gifId',
+  singleGifRule(),
+  validateData,
+  gifsCtrl.deleteGif,
 );
 
 gifsRouter.use('/:gifId/comments', gifCommentsRouter);


### PR DESCRIPTION
[Delivers #16]

Employees can delete their own gifs

#### What does this PR do?
Enables employees to delete their gif posts

#### Description of Task to be completed?
- Create route for endpoint
- Define validation rules
- Create controller to delete gif post

#### How should this be manually tested?
- Send a DELETE request to /api/v1/gifs/:gifId
   - with a valid token
   - a valid gifId
- Expect a JSON response and status code 200 on success
- Expect 422 for invalid data
- Expect 401 for invalid token