### PR TITLE
PR - feature - Employees can flag articles, gifs, comments as inappropriate

### DIFF
--- a/src/api/v1/controllers/articleCommentsController.js
+++ b/src/api/v1/controllers/articleCommentsController.js
@@ -31,6 +31,82 @@ const articleCommentsCtrl = {
     }
   },
 
+  flagComment: async (req, res, next) => {
+    try {
+      // flag article
+      const articleComment = await ArticleComment.getbyId(req.params.commentId);
+
+      // console.log(JSON.stringify(article));
+      // console.log(JSON.stringify(articleComment));
+
+      console.log(`req user Id: ${req.user.userId}`);
+
+      console.log(`comment user id: ${articleComment.user_id}`);
+
+
+      if (Number(req.params.articleId) !== articleComment.article_id) {
+        console.log('got here');
+        return next(new CustomError(403, 'comment does not belong to specified article'));
+      }
+
+      // user cant flag their own comment
+      if (Number(req.user.userId) === articleComment.user_id) {
+        return next(new CustomError(403, 'User cannot flag his/her own comment'));
+      }
+
+      const success = await articleComment.flag();
+
+      if (success) {
+        return responseHandler(res, 200, {
+          message: 'Comment successfully flagged',
+          commentId: articleComment.article_comment_id,
+        });
+      }
+
+      return next(new CustomError(500, 'Error flagging comment'));
+
+      // console.log(`article comment: ${JSON.stringify(articleComment)}`);
+    } catch (error) {
+      // console.log(`error creating user: ${error.message}`);
+      if (error.message.indexOf('not found') >= 0) {
+        return next(new CustomError(404, 'Article not found'));
+      }
+
+      return next(error);
+    }
+  },
+
+  unflagComment: async (req, res, next) => {
+    try {
+      // flag article
+      const articleComment = await ArticleComment.getbyId(req.params.commentId);
+
+      if (Number(req.params.articleId) !== articleComment.article_id) {
+        console.log('got here');
+        return next(new CustomError(403, 'comment does not belong to specified article'));
+      }
+
+      const success = await articleComment.unflag();
+
+      if (success) {
+        return responseHandler(res, 200, {
+          message: 'Comment successfully unflagged',
+          commentId: articleComment.article_comment_id,
+        });
+      }
+
+      return next(new CustomError(500, 'Error unflagging comment'));
+
+      // console.log(`article comment: ${JSON.stringify(articleComment)}`);
+    } catch (error) {
+      // console.log(`error creating user: ${error.message}`);
+      if (error.message.indexOf('not found') >= 0) {
+        return next(new CustomError(404, 'Article not found'));
+      }
+
+      return next(error);
+    }
+  },
 
 };
 

--- a/src/api/v1/controllers/articlesController.js
+++ b/src/api/v1/controllers/articlesController.js
@@ -231,7 +231,7 @@ const articlesCtrl = {
         });
       }
 
-      return next(new CustomError(500, 'Error unflagging comment'));
+      return next(new CustomError(500, 'Error unflagging article'));
 
       // console.log(`article comment: ${JSON.stringify(article)}`);
     } catch (error) {

--- a/src/api/v1/controllers/articlesController.js
+++ b/src/api/v1/controllers/articlesController.js
@@ -103,7 +103,7 @@ const articlesCtrl = {
       // map DB comments fields and return selected and renamed fields
       const mappedComments = article.comments.map((comment) => {
         const mapped = {};
-        mapped.commentId = comment.article_comment_id;
+        mapped.commentId = comment.article_id;
         mapped.comment = comment.comment;
         mapped.authorId = comment.user_id;
         mapped.authorName = comment.author_name;
@@ -172,6 +172,72 @@ const articlesCtrl = {
           articles: [],
           message: 'No articles found',
         });
+      }
+
+      return next(error);
+    }
+  },
+
+  flagArticle: async (req, res, next) => {
+    try {
+      // flag article
+      const article = await Article.getbyId(req.params.articleId);
+
+      // console.log(JSON.stringify(article));
+      // console.log(JSON.stringify(article));
+
+      console.log(`req user Id: ${req.user.userId}`);
+      console.log(`article user id: ${article.user_id}`);
+
+
+      // user cant flag their own article
+      if (Number(req.user.userId) === article.user_id) {
+        return next(new CustomError(403, 'User cannot flag his/her own article'));
+      }
+
+      const success = await article.flag();
+
+      if (success) {
+        return responseHandler(res, 200, {
+          message: 'Article successfully flagged',
+          articleId: article.article_id,
+        });
+      }
+
+      return next(new CustomError(500, 'Error flagging article'));
+
+      // console.log(`article article: ${JSON.stringify(article)}`);
+    } catch (error) {
+      // console.log(`error creating user: ${error.message}`);
+      if (error.message.indexOf('not found') >= 0) {
+        return next(new CustomError(404, 'Article not found'));
+      }
+
+      return next(error);
+    }
+  },
+
+  unflagArticle: async (req, res, next) => {
+    try {
+      // flag article
+      const article = await Article.getbyId(req.params.articleId);
+
+      const success = await article.unflag();
+
+      if (success) {
+        return responseHandler(res, 200, {
+          message: 'Article successfully unflagged',
+          articleId: article.article_id,
+        });
+      }
+
+      return next(new CustomError(500, 'Error unflagging comment'));
+
+      // console.log(`article comment: ${JSON.stringify(article)}`);
+    } catch (error) {
+      // console.log(`error creating user: ${error.message}`);
+      if (error.message.indexOf('not found') >= 0) {
+        return next(new CustomError(404, 'Article not found'));
       }
 
       return next(error);

--- a/src/api/v1/controllers/feedController.js
+++ b/src/api/v1/controllers/feedController.js
@@ -12,8 +12,8 @@ const feedCtrl = {
 
         mapped.id = row.id;
         mapped.title = row.title;
-        mapped.article = row.article;
-        mapped.url = row.image_url;
+        mapped.article = row.article === null ? undefined : row.article;
+        mapped.url = row.image_url === null ? undefined : row.image_url;
         mapped.authorId = row.author_id;
         mapped.authorName = row.author_name;
         mapped.createdOn = row.created_on;

--- a/src/api/v1/controllers/gifCommentsController.js
+++ b/src/api/v1/controllers/gifCommentsController.js
@@ -30,6 +30,83 @@ const gifCommentsCtrl = {
     }
   },
 
+  flagComment: async (req, res, next) => {
+    try {
+      // flag gif
+      const gifComment = await GifComment.getbyId(req.params.commentId);
+
+      // console.log(JSON.stringify(gif));
+      // console.log(JSON.stringify(gifComment));
+
+      console.log(`req user Id: ${req.user.userId}`);
+
+      console.log(`comment user id: ${gifComment.user_id}`);
+
+
+      if (Number(req.params.gifId) !== gifComment.gif_id) {
+        console.log('got here');
+        return next(new CustomError(403, 'comment does not belong to specified gif'));
+      }
+
+      // user cant flag their own comment
+      if (Number(req.user.userId) === gifComment.user_id) {
+        return next(new CustomError(403, 'User cannot flag his/her own comment'));
+      }
+
+      const success = await gifComment.flag();
+
+      if (success) {
+        return responseHandler(res, 200, {
+          message: 'Comment successfully flagged',
+          commentId: gifComment.gif_comment_id,
+        });
+      }
+
+      return next(new CustomError(500, 'Error flagging comment'));
+
+      // console.log(`gif comment: ${JSON.stringify(gifComment)}`);
+    } catch (error) {
+      // console.log(`error creating user: ${error.message}`);
+      if (error.message.indexOf('not found') >= 0) {
+        return next(new CustomError(404, 'Gif not found'));
+      }
+
+      return next(error);
+    }
+  },
+
+  unflagComment: async (req, res, next) => {
+    try {
+      // flag gif
+      const gifComment = await GifComment.getbyId(req.params.commentId);
+
+      if (Number(req.params.gifId) !== gifComment.gif_id) {
+        console.log('got here');
+        return next(new CustomError(403, 'comment does not belong to specified gif'));
+      }
+
+      const success = await gifComment.unflag();
+
+      if (success) {
+        return responseHandler(res, 200, {
+          message: 'Comment successfully unflagged',
+          commentId: gifComment.gif_comment_id,
+        });
+      }
+
+      return next(new CustomError(500, 'Error unflagging comment'));
+
+      // console.log(`gif comment: ${JSON.stringify(gifComment)}`);
+    } catch (error) {
+      // console.log(`error creating user: ${error.message}`);
+      if (error.message.indexOf('not found') >= 0) {
+        return next(new CustomError(404, 'Gif not found'));
+      }
+
+      return next(error);
+    }
+  },
+
 
 };
 

--- a/src/api/v1/controllers/gifsController.js
+++ b/src/api/v1/controllers/gifsController.js
@@ -100,6 +100,72 @@ const gifsCtrl = {
     }
   },
 
+  flagGif: async (req, res, next) => {
+    try {
+      // flag gif
+      const gif = await Gif.getbyId(req.params.gifId);
+
+      // console.log(JSON.stringify(gif));
+      // console.log(JSON.stringify(gif));
+
+      console.log(`req user Id: ${req.user.userId}`);
+      console.log(`gif user id: ${gif.user_id}`);
+
+
+      // user cant flag their own gif
+      if (Number(req.user.userId) === gif.user_id) {
+        return next(new CustomError(403, 'User cannot flag his/her own gif'));
+      }
+
+      const success = await gif.flag();
+
+      if (success) {
+        return responseHandler(res, 200, {
+          message: 'Gif successfully flagged',
+          gifId: gif.gif_id,
+        });
+      }
+
+      return next(new CustomError(500, 'Error flagging gif'));
+
+      // console.log(`gif gif: ${JSON.stringify(gif)}`);
+    } catch (error) {
+      // console.log(`error creating user: ${error.message}`);
+      if (error.message.indexOf('not found') >= 0) {
+        return next(new CustomError(404, 'Gif not found'));
+      }
+
+      return next(error);
+    }
+  },
+
+  unflagGif: async (req, res, next) => {
+    try {
+      // flag gif
+      const gif = await Gif.getbyId(req.params.gifId);
+
+      const success = await gif.unflag();
+
+      if (success) {
+        return responseHandler(res, 200, {
+          message: 'Gif successfully unflagged',
+          gifId: gif.gif_id,
+        });
+      }
+
+      return next(new CustomError(500, 'Error unflagging gif'));
+
+      // console.log(`gif gif: ${JSON.stringify(gif)}`);
+    } catch (error) {
+      // console.log(`error creating user: ${error.message}`);
+      if (error.message.indexOf('not found') >= 0) {
+        return next(new CustomError(404, 'Gif not found'));
+      }
+
+      return next(error);
+    }
+  },
+
 
 };
 

--- a/src/api/v1/routes/articles/comments/index.js
+++ b/src/api/v1/routes/articles/comments/index.js
@@ -7,8 +7,8 @@ import articleCommentsCtrl from '../../../controllers/articleCommentsController'
 const articleCommentsRouter = express.Router({ mergeParams: true });
 
 articleCommentsRouter.post('/', addArticleCommentRule(), validateData, articleCommentsCtrl.addComment);
-// articleCommentsRouter.post('/:commentId/flag', articleCommentsCtrl.flagComment);
-// articleCommentsRouter.post('/:commentId/unflag', articleCommentsCtrl.unflagComment);
+articleCommentsRouter.post('/:commentId/flag', articleCommentsCtrl.flagComment);
+articleCommentsRouter.post('/:commentId/unflag', articleCommentsCtrl.unflagComment);
 // articleCommentsRouter.delete('/:commentId', articleCommentsCtrl.deleteComment);
 
 export default articleCommentsRouter;

--- a/src/api/v1/routes/articles/index.js
+++ b/src/api/v1/routes/articles/index.js
@@ -36,6 +36,21 @@ articlesRouter.get(
   articlesCtrl.viewArticle,
 );
 
+articlesRouter.post(
+  '/:articleId/flag',
+  singleArticleRule(),
+  validateData,
+  articlesCtrl.flagArticle,
+);
+
+articlesRouter.post(
+  '/:articleId/unflag',
+  singleArticleRule(),
+  validateData,
+  articlesCtrl.unflagArticle,
+);
+
+
 articlesRouter.use('/:articleId/comments', articleCommentsRouter);
 
 export default articlesRouter;

--- a/src/api/v1/routes/gifs/comments/index.js
+++ b/src/api/v1/routes/gifs/comments/index.js
@@ -6,6 +6,8 @@ import { addGifCommentRule } from '../../../middleware/validationRules';
 const gifCommentsRouter = express.Router({ mergeParams: true });
 
 gifCommentsRouter.post('/', addGifCommentRule(), validateData, gifCommentsCtrl.addComment);
+gifCommentsRouter.post('/:commentId/flag', gifCommentsCtrl.flagComment);
+gifCommentsRouter.post('/:commentId/unflag', gifCommentsCtrl.unflagComment);
 
 
 export default gifCommentsRouter;

--- a/src/api/v1/routes/gifs/index.js
+++ b/src/api/v1/routes/gifs/index.js
@@ -29,6 +29,20 @@ gifsRouter.get(
   gifsCtrl.viewGif,
 );
 
+gifsRouter.post(
+  '/:gifId/flag',
+  singleGifRule(),
+  validateData,
+  gifsCtrl.flagGif,
+);
+
+gifsRouter.post(
+  '/:gifId/unflag',
+  singleGifRule(),
+  validateData,
+  gifsCtrl.unflagGif,
+);
+
 gifsRouter.use('/:gifId/comments', gifCommentsRouter);
 
 export default gifsRouter;

--- a/tests/api/v1/routes/articleCommentsRoute.test.js
+++ b/tests/api/v1/routes/articleCommentsRoute.test.js
@@ -9,7 +9,7 @@ describe('Article comments resource endpoints integration tests', () => {
   let ADMIN_TOKEN;
   let USER_TOKEN;
   let ADMIN_ARTICLE_ID;
-  // let USER_ARTICLE_ID;
+  let USER_ARTICLE_ID;
 
   before(async () => {
     ADMIN_TOKEN = generateToken(
@@ -41,7 +41,7 @@ describe('Article comments resource endpoints integration tests', () => {
     userArticle.user_id = 2;
     await userArticle.save();
 
-    // USER_ARTICLE_ID = userArticle.article_id;
+    USER_ARTICLE_ID = userArticle.article_id;
   });
 
   describe('POST: /articles/:articleId/comments', () => {
@@ -115,6 +115,172 @@ describe('Article comments resource endpoints integration tests', () => {
               return done();
             });
         });
+      });
+    });
+  });
+
+  describe('POST: /articles/:articleId/comments/:commentId/flag', () => {
+    let commentId;
+    before(async () => {
+      const userArticle = await Article.getbyId(USER_ARTICLE_ID);
+      commentId = await userArticle.addComment(1, 'Nice');
+    });
+
+    describe('when an unauthenticated user requests to flag a comment', () => {
+      it('should reply with error no authorization token found, 401', (done) => {
+        request(app)
+          .post(`/api/v1/articles/${USER_ARTICLE_ID}/comments/${commentId}/flag`)
+          .set('Accept', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(401)
+          .end((err, res) => {
+            if (err) return done(err);
+            expect(res.body).to.have.property('status', 'error');
+            expect(res.body.error).to.contain('No authorization token');
+            return done();
+          });
+      });
+    });
+
+    describe('when an authenticated user requests to flag their own comment', () => {
+      it('should return error that user cannot flag their own comment', (done) => {
+        request(app)
+          .post(`/api/v1/articles/${USER_ARTICLE_ID}/comments/${commentId}/flag`)
+          .set('Accept', 'application/json')
+          .set('Authorization', `Bearer ${ADMIN_TOKEN}`)
+          .expect('Content-Type', /json/)
+          .expect(403)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+            expect(res.body).to.have.property('status', 'error');
+            expect(res.body.error).to.contain('cannot flag');
+            return done();
+          });
+      });
+    });
+
+    describe('when an authenticated user requests to flag a non-existent comment', () => {
+      it('should return error that comment not found', (done) => {
+        request(app)
+          .post(`/api/v1/articles/${ADMIN_ARTICLE_ID}/comments/777/flag`)
+          .set('Accept', 'application/json')
+          .set('Authorization', `Bearer ${USER_TOKEN}`)
+          .expect('Content-Type', /json/)
+          .expect(404)
+          .end((err, res) => {
+            if (err) {
+              console.log(err);
+              return done(err);
+            }
+
+            expect(res.body).to.have.property('status', 'error');
+            expect(res.body.error).to.contain('not found');
+            return done();
+          });
+      });
+    });
+
+    describe('when an authenticated user requests to flag another user\'s comment', () => {
+      it('should return success message and commentId', (done) => {
+        request(app)
+          .post(`/api/v1/articles/${USER_ARTICLE_ID}/comments/${commentId}/flag`)
+          .set('Authorization', `Bearer ${USER_TOKEN}`)
+          .expect(200)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            expect(res.body).to.have.property('status', 'success');
+            expect(res.body.data).to.have.property('commentId', commentId);
+            expect(res.body.data).to.have.property('message', 'Comment successfully flagged');
+
+            return done();
+          });
+      });
+    });
+  });
+
+  describe('POST: /articles/:articleId/comments/:commentId/unflag', () => {
+    let commentId;
+    before(async () => {
+      const userArticle = await Article.getbyId(USER_ARTICLE_ID);
+      commentId = await userArticle.addComment(1, 'Nice');
+    });
+
+    describe('when an unauthenticated user requests to unflag a comment', () => {
+      it('should reply with error no authorization token found, 401', (done) => {
+        request(app)
+          .post(`/api/v1/articles/${USER_ARTICLE_ID}/comments/${commentId}/unflag`)
+          .set('Accept', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(401)
+          .end((err, res) => {
+            if (err) return done(err);
+            expect(res.body).to.have.property('status', 'error');
+            expect(res.body.error).to.contain('No authorization token');
+            return done();
+          });
+      });
+    });
+
+    describe('when an authenticated/unauthorized user requests to unflag a comment', () => {
+      it('should return error that user does not have permissions', (done) => {
+        request(app)
+          .post(`/api/v1/articles/${USER_ARTICLE_ID}/comments/${commentId}/unflag`)
+          .set('Accept', 'application/json')
+          .set('Authorization', `Bearer ${USER_TOKEN}`)
+          .expect('Content-Type', /json/)
+          .expect(403)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+            expect(res.body).to.have.property('status', 'error');
+            expect(res.body.error).to.contain('Permission denied');
+            return done();
+          });
+      });
+    });
+
+    describe('when an authenticated/authorized user requests to unflag a non-existent comment', () => {
+      it('should return error that comment not found', (done) => {
+        request(app)
+          .post(`/api/v1/articles/${USER_ARTICLE_ID}/comments/777/unflag`)
+          .set('Accept', 'application/json')
+          .set('Authorization', `Bearer ${ADMIN_TOKEN}`)
+          .expect('Content-Type', /json/)
+          .expect(404)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+            expect(res.body).to.have.property('status', 'error');
+            expect(res.body.error).to.contain('not found');
+            return done();
+          });
+      });
+    });
+
+    describe('when an authenticated/authorized user requests to unflag a comment', () => {
+      it('should return success message and commentId', (done) => {
+        request(app)
+          .post(`/api/v1/articles/${USER_ARTICLE_ID}/comments/${commentId}/unflag`)
+          .set('Authorization', `Bearer ${ADMIN_TOKEN}`)
+          .expect(200)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            expect(res.body).to.have.property('status', 'success');
+            expect(res.body.data).to.have.property('commentId', commentId);
+            expect(res.body.data).to.have.property('message', 'Comment successfully unflagged');
+
+            return done();
+          });
       });
     });
   });


### PR DESCRIPTION
[Closes #23 ]

#### What does this PR do?
Enables employees flag articles, gif and comments as inappropriate, Admin can unflag them

#### Description of Task to be completed?
Create routes for flagging/unflagging the various resources

#### How should this be manually tested?
POST /api/v1/gifs/:gifId/flag
POST /api/v1/gifs/:gifId/unflag
POST /api/v1/gifs/:gifId/comments/:commentId/flag
POST /api/v1/gifs/:gifId/comments/:commentId/unflag
POST /api/v1/articles/:articleId/flag
POST /api/v1/articles/:articleId/unflag
POST /api/v1/articles/:articleId/comments/:commentId/flag
POST /api/v1/articles/:articleId/comments/:commentId/unflag

- All routes require 
 - a valid token 
 - a valid resource Id
- Unflag routes require an admin token

